### PR TITLE
allowing fortran codes to use if fs_is_serialization_on() by adding i…

### DIFF
--- a/src/serialbox-python/pp_ser/pp_ser.py
+++ b/src/serialbox-python/pp_ser/pp_ser.py
@@ -353,7 +353,10 @@ class PpSer:
     def __ser_verbatim(self, args):
         # simply remove $!SER directive for verbatim statements
         self.__line = ' '.join(args[1:]) + '\n'
-
+        for arg in args:
+            if 'fs_is_serialization_on' in arg:
+                self.__calls.add('fs_is_serialization_on')
+    
     # REGISTER directive
     def __ser_register(self, args):
 


### PR DESCRIPTION
…t to the USE mod when it comes up in verbatim

This is potentially in conflict with serialbox intention/design, though is a simple change to allow one to check if serialization is on and store than in a variable. Basically there are some modules that are used for our serialization tests that get called in other parts of the code with a small subset of k's -- it seems convenient to just turn serialization off around those calls and use a temporary variable to turn serialization back on if it was already.