### PR TITLE
Two new features for pp_ser.py

### DIFF
--- a/src/serialbox-fortran/utils_ppser.f90
+++ b/src/serialbox-fortran/utils_ppser.f90
@@ -63,10 +63,11 @@ CONTAINS
 
 !============================================================================
 
-SUBROUTINE ppser_initialize(directory, directory_ref, prefix, mode, prefix_ref, mpi_rank, rprecision, rperturb, realtype, archive, unique_id)
+SUBROUTINE ppser_initialize(directory, prefix, mode, directory_ref, prefix_ref, &
+                mpi_rank, rprecision, rperturb, realtype, archive, unique_id)
   CHARACTER(LEN=*), INTENT(IN)           :: directory, prefix
   INTEGER, OPTIONAL, INTENT(IN)          :: mode
-  CHARACTER(LEN=*), OPTIONAL, INTENT(IN) :: prefix_ref, directory_ref
+  CHARACTER(LEN=*), OPTIONAL, INTENT(IN) :: prefix_ref, directory_ref  ! use a different serializer for reading (optional)
   INTEGER, OPTIONAL, INTENT(IN)          :: mpi_rank
   REAL(KIND=8), OPTIONAL, INTENT(IN)     :: rprecision, rperturb
   INTEGER, OPTIONAL, INTENT(IN)          :: realtype

--- a/src/serialbox-fortran/utils_ppser.f90
+++ b/src/serialbox-fortran/utils_ppser.f90
@@ -63,20 +63,26 @@ CONTAINS
 
 !============================================================================
 
-SUBROUTINE ppser_initialize(directory, prefix, mode, prefix_ref, mpi_rank, rprecision, rperturb, realtype, archive, unique_id)
+SUBROUTINE ppser_initialize(directory, directory_ref, prefix, mode, prefix_ref, mpi_rank, rprecision, rperturb, realtype, archive, unique_id)
   CHARACTER(LEN=*), INTENT(IN)           :: directory, prefix
   INTEGER, OPTIONAL, INTENT(IN)          :: mode
-  CHARACTER(LEN=*), OPTIONAL, INTENT(IN) :: prefix_ref
+  CHARACTER(LEN=*), OPTIONAL, INTENT(IN) :: prefix_ref, directory_ref
   INTEGER, OPTIONAL, INTENT(IN)          :: mpi_rank
   REAL(KIND=8), OPTIONAL, INTENT(IN)     :: rprecision, rperturb
   INTEGER, OPTIONAL, INTENT(IN)          :: realtype
   CHARACTER(LEN=*), INTENT(IN), OPTIONAL :: archive
   LOGICAL, INTENT(IN), OPTIONAL          :: unique_id
 
+  CHARACTER(LEN=256)                     :: dir_ref
   CHARACTER(LEN=1), DIMENSION(128)       :: buffer
   CHARACTER(LEN=15)                      :: suffix
   INTEGER                                :: intvalue
   
+  IF (PRESENT(directory_ref)) THEN
+    dir_ref = directory_ref
+  ELSE
+    dir_ref = directory
+  ENDIF
 
   ! Initialize serializer and savepoint
   IF ( .NOT. ppser_initialized ) THEN
@@ -102,15 +108,15 @@ SUBROUTINE ppser_initialize(directory, prefix, mode, prefix_ref, mpi_rank, rprec
       ppser_hasref = .true.
       IF ( PRESENT(mpi_rank) ) THEN
         IF ( PRESENT(archive) ) THEN
-          CALL fs_create_serializer(directory, TRIM(prefix_ref)//TRIM(suffix), 'r', ppser_serializer_ref, archive)
+          CALL fs_create_serializer(dir_ref, TRIM(prefix_ref)//TRIM(suffix), 'r', ppser_serializer_ref, archive)
         ELSE
-          CALL fs_create_serializer(directory, TRIM(prefix_ref)//TRIM(suffix), 'r', ppser_serializer_ref)
+          CALL fs_create_serializer(dir_ref, TRIM(prefix_ref)//TRIM(suffix), 'r', ppser_serializer_ref)
         END IF
       ELSE
         IF ( PRESENT(archive) ) THEN
-          CALL fs_create_serializer(directory, TRIM(prefix_ref), 'r', ppser_serializer_ref, archive)
+          CALL fs_create_serializer(dir_ref, TRIM(prefix_ref), 'r', ppser_serializer_ref, archive)
         ELSE
-          CALL fs_create_serializer(directory, TRIM(prefix_ref), 'r', ppser_serializer_ref)
+          CALL fs_create_serializer(dir_ref, TRIM(prefix_ref), 'r', ppser_serializer_ref)
         END IF
       END IF
     END IF

--- a/src/serialbox-fortran/utils_ppser.f90
+++ b/src/serialbox-fortran/utils_ppser.f90
@@ -67,7 +67,7 @@ SUBROUTINE ppser_initialize(directory, prefix, mode, directory_ref, prefix_ref, 
                 mpi_rank, rprecision, rperturb, realtype, archive, unique_id)
   CHARACTER(LEN=*), INTENT(IN)           :: directory, prefix
   INTEGER, OPTIONAL, INTENT(IN)          :: mode
-  CHARACTER(LEN=*), OPTIONAL, INTENT(IN) :: prefix_ref, directory_ref  ! use a different serializer for reading (optional)
+  CHARACTER(LEN=*), OPTIONAL, INTENT(IN) :: directory_ref, prefix_ref ! use a different serializer for reading (optional)
   INTEGER, OPTIONAL, INTENT(IN)          :: mpi_rank
   REAL(KIND=8), OPTIONAL, INTENT(IN)     :: rprecision, rperturb
   INTEGER, OPTIONAL, INTENT(IN)          :: realtype

--- a/src/serialbox-python/pp_ser/pp_ser.py
+++ b/src/serialbox-python/pp_ser/pp_ser.py
@@ -462,7 +462,7 @@ class PpSer:
         self.__calls.add(self.methods['spinfo'])
         l += tab + 'call ' + self.methods['savepoint'] + '(' + name + ', ppser_savepoint)\n'
         for k, v in zip(keys, values):
-            l += tab + 'call ' + self.methods['spinfo'] + '(ppser_savepoint, \'' + k + '\', ' + v + ')\n'
+            l += tab + 'call ' + self.methods['spinfo'] + '(ppser_savepoint, ' + k + ', ' + v + ')\n'
 
         if if_statement:
             l += 'ENDIF\n'

--- a/src/serialbox-python/pp_ser/pp_ser.py
+++ b/src/serialbox-python/pp_ser/pp_ser.py
@@ -278,9 +278,9 @@ class PpSer:
             l += 'IF (' + if_statement + ') THEN\n'
             tab = '  '
 
-        l += tab + 'PRINT *, \'>>>>>>>>>>>>>>>>>><<<<<<<<<<<<<<<<<<\'\n'
-        l += tab + 'PRINT *, \'>>> WARNING: SERIALIZATION IS ON <<<\'\n'
-        l += tab + 'PRINT *, \'>>>>>>>>>>>>>>>>>><<<<<<<<<<<<<<<<<<\'\n'
+#        l += tab + 'PRINT *, \'>>>>>>>>>>>>>>>>>><<<<<<<<<<<<<<<<<<\'\n'
+#        l += tab + 'PRINT *, \'>>> WARNING: SERIALIZATION IS ON <<<\'\n'
+#        l += tab + 'PRINT *, \'>>>>>>>>>>>>>>>>>><<<<<<<<<<<<<<<<<<\'\n'
         l += tab + '\n'
         l += tab + '! setup serialization environment\n'
 

--- a/src/serialbox-python/pp_ser/pp_ser.py
+++ b/src/serialbox-python/pp_ser/pp_ser.py
@@ -460,7 +460,7 @@ class PpSer:
 
         self.__calls.add(self.methods['savepoint'])
         self.__calls.add(self.methods['spinfo'])
-        l += tab + 'call ' + self.methods['savepoint'] + '(\'' + name + '\', ppser_savepoint)\n'
+        l += tab + 'call ' + self.methods['savepoint'] + '(' + name + ', ppser_savepoint)\n'
         for k, v in zip(keys, values):
             l += tab + 'call ' + self.methods['spinfo'] + '(ppser_savepoint, \'' + k + '\', ' + v + ')\n'
 

--- a/src/serialbox-python/pp_ser/pp_ser.py
+++ b/src/serialbox-python/pp_ser/pp_ser.py
@@ -77,7 +77,7 @@ class PpSer:
 
     def __init__(self, infile, outfile='', ifdef='SERIALIZE', real='ireals',
                  module='m_serialize', identical=True, verbose=False,
-                 acc_prefix=True, acc_if='', modules=''):
+                 acc_prefix=True, acc_if='', modules='', sp_as_var=False):
 
         # public variables
         self.verbose = verbose
@@ -89,6 +89,7 @@ class PpSer:
         self.identical = identical    # write identical files (no preprocessing done)?
         self.acc_prefix = acc_prefix  # generate preprocessing marco for ACC_PREFIX
         self.acc_if = acc_if          # generate IF clause after OpenACC update
+        self.sp_as_var = sp_as_var    # Syntax for savepoints using variable instead of string
 
         # setup (also public)
         self.methods = {
@@ -278,9 +279,9 @@ class PpSer:
             l += 'IF (' + if_statement + ') THEN\n'
             tab = '  '
 
-#        l += tab + 'PRINT *, \'>>>>>>>>>>>>>>>>>><<<<<<<<<<<<<<<<<<\'\n'
-#        l += tab + 'PRINT *, \'>>> WARNING: SERIALIZATION IS ON <<<\'\n'
-#        l += tab + 'PRINT *, \'>>>>>>>>>>>>>>>>>><<<<<<<<<<<<<<<<<<\'\n'
+        l += tab + 'PRINT *, \'>>>>>>>>>>>>>>>>>><<<<<<<<<<<<<<<<<<\'\n'
+        l += tab + 'PRINT *, \'>>> WARNING: SERIALIZATION IS ON <<<\'\n'
+        l += tab + 'PRINT *, \'>>>>>>>>>>>>>>>>>><<<<<<<<<<<<<<<<<<\'\n'
         l += tab + '\n'
         l += tab + '! setup serialization environment\n'
 
@@ -460,9 +461,14 @@ class PpSer:
 
         self.__calls.add(self.methods['savepoint'])
         self.__calls.add(self.methods['spinfo'])
-        l += tab + 'call ' + self.methods['savepoint'] + '(' + name + ', ppser_savepoint)\n'
-        for k, v in zip(keys, values):
-            l += tab + 'call ' + self.methods['spinfo'] + '(ppser_savepoint, ' + k + ', ' + v + ')\n'
+        if not self.sp_as_var:
+            l += tab + 'call ' + self.methods['savepoint'] + '(\'' + name + '\', ppser_savepoint)\n'
+            for k, v in zip(keys, values):
+                l += tab + 'call ' + self.methods['spinfo'] + '(ppser_savepoint, \'' + k + '\', ' + v + ')\n'
+        else:
+            l += tab + 'call ' + self.methods['savepoint'] + '(' + name + ', ppser_savepoint)\n'
+            for k, v in zip(keys, values):
+                l += tab + 'call ' + self.methods['spinfo'] + '(ppser_savepoint, ' + k + ', ' + v + ')\n'
 
         if if_statement:
             l += 'ENDIF\n'
@@ -1057,6 +1063,8 @@ def parse_args():
                       default='', type=str, dest='acc_if')
     parser.add_option('-m', '--module', help='Extra MODULE to be add to the use statement',
                       default='', type=str, dest='modules')
+    parser.add_option('-s', '--sp-as-var', help='Savepoint specified as variable instead of string',
+                      default=False, action='store_true', dest='sp_as_var')
     (options, args) = parser.parse_args()
     if len(args) < 1:
         parser.error('Need at least one source file to process')
@@ -1098,5 +1106,5 @@ if __name__ == "__main__":
             print('Processing file', infile)
             ser = PpSer(infile, real='wp', outfile=outfile, identical=(not options.ignore_identical),
                         verbose=options.verbose, acc_prefix=options.acc_prefix, acc_if=options.acc_if,
-                        modules=options.modules)
+                        modules=options.modules, sp_as_var=options.sp_as_var)
             ser.preprocess()

--- a/src/serialbox-python/pp_ser/pp_ser.py
+++ b/src/serialbox-python/pp_ser/pp_ser.py
@@ -463,12 +463,10 @@ class PpSer:
         self.__calls.add(self.methods['spinfo'])
         if not self.sp_as_var:
             l += tab + 'call ' + self.methods['savepoint'] + '(\'' + name + '\', ppser_savepoint)\n'
-            for k, v in zip(keys, values):
-                l += tab + 'call ' + self.methods['spinfo'] + '(ppser_savepoint, \'' + k + '\', ' + v + ')\n'
         else:
             l += tab + 'call ' + self.methods['savepoint'] + '(' + name + ', ppser_savepoint)\n'
-            for k, v in zip(keys, values):
-                l += tab + 'call ' + self.methods['spinfo'] + '(ppser_savepoint, ' + k + ', ' + v + ')\n'
+        for k, v in zip(keys, values):
+            l += tab + 'call ' + self.methods['spinfo'] + '(ppser_savepoint, \'' + k + '\', ' + v + ')\n'
 
         if if_statement:
             l += 'ENDIF\n'


### PR DESCRIPTION
This PR adds two new features to `pp_ser.py`. Changes are located in `pp_ser.py` and `utils_ppser.f90` only.

1. When initializing `pp_ser.py` with reference data one can specify another directory where the data is located. If this is not available, new data will be serialized into the same directory as the reference data which can lead to conflicts or corrupt data.
2. Up to now, the directive syntax for specifying a savepoint was `!$ser savepoint gugus` where gugus was the name of the savepoint. This syntax does not allow the dynamic generation of savepoint names (e.g. from runtime information such as timestep or a unique ID). A new command line option to `pp_ser.py` named `-s` or `--sp-as-var` allows to use `!$ser savepoint "gugus"` or `!$ser savepoint my_string` where `my_string` is a variable.

Note: This PR would allow us to build physics_standalone against master and potentially merge all changes we have made to serialbox to the upstream repo managed by CSCS. Once this is done, we could delete our fork.

Note 2: @gmao-ckung As you may have noticed, the physics standalone relies on feature 2. Once we have this in master, you could simply update your build of serialbox to the latest master.